### PR TITLE
Add test case for getParametersType with nested path

### DIFF
--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -4,6 +4,7 @@ import { getParametersType } from "./core.js";
 
 test("getParametersType()", () => {
   assert.strictEqual(getParametersType('foo'), 'unknown');
+  assert.strictEqual(getParametersType('foo/bar'), 'unknown');
   assert.strictEqual(getParametersType('app/blog/[slug]'), '{\'slug\':string|typeof emptyParamSymbol}');
   assert.strictEqual(getParametersType('app/shop/[...slug]'), '{\'slug\':string[]}');
   assert.strictEqual(getParametersType('app/shop/[[...slug]]'), '{\'slug\'?:string[]}');


### PR DESCRIPTION
Test case for `foo/bar` 😉